### PR TITLE
fix(kmono-git): add missing GraalVM reflect entry for DiffAlgorithm$SupportedAlgorithm

### DIFF
--- a/packages/kmono-git/resources/META-INF/native-image/org.eclipse.jgit/org.eclipse.jgit/reflect-config.json
+++ b/packages/kmono-git/resources/META-INF/native-image/org.eclipse.jgit/org.eclipse.jgit/reflect-config.json
@@ -215,5 +215,19 @@
         ]
       }
     ]
+  },
+  {
+    "name": "org.eclipse.jgit.diff.DiffAlgorithm$SupportedAlgorithm",
+    "condition": {
+      "typeReachable": "org.eclipse.jgit.diff.DiffFormatter"
+    },
+    "methods": [
+      {
+        "name": "values",
+        "parameterTypes": [
+
+        ]
+      }
+    ]
   }
 ]


### PR DESCRIPTION
## Problem

Any `kmono` CLI command that triggers file-level change detection (`--with-changes-since`, `--with-changes` combined with `--ignore-changes`) crashes with:

```
java.lang.NoSuchMethodException:
  org.eclipse.jgit.diff.DiffAlgorithm$SupportedAlgorithm.values()
```

Reproducible with:
```bash
kmono query --with-changes-since origin/main --include-keys name -o json
```

## Cause

`DiffFormatter.setRepository()` (called from `k16.kmono.git.files/find-commit-changed-files` at `files.clj:62`) internally calls `Config.getEnum()` which uses reflection to invoke `DiffAlgorithm$SupportedAlgorithm.values()`. This enum is not registered in the GraalVM native-image reflection config, so the `values()` method is stripped during compilation.

Call chain:
```
k16.kmono.git.files/find-commit-changed-files
  → DiffFormatter.setRepository()
    → DiffFormatter.setReader()
      → Config.getEnum("diff", null, "algorithm", SupportedAlgorithm.HISTOGRAM)
        → Config.allValuesOf(SupportedAlgorithm.class)
          → SupportedAlgorithm.class.getMethod("values")  ← NoSuchMethodException
```

## Fix

Added `org.eclipse.jgit.diff.DiffAlgorithm$SupportedAlgorithm` to `packages/kmono-git/resources/META-INF/native-image/org.eclipse.jgit/org.eclipse.jgit/reflect-config.json`, following the same pattern as the 16 other JGit enums already registered (e.g. `CoreConfig$AutoCRLF`, `CoreConfig$EOL`, `SHA1$Sha1Implementation`, etc.).

## Verification

Built native binary from this branch and confirmed `--with-changes-since` works:
```bash
$ kmono query --with-changes-since origin/main --filter-unchanged --include-keys name -o json

```


Note: This PR is AI generated but I build the native binary locally and it works as expected. I am currently using a fork fix until this is addressed in kmono directly: https://github.com/ovistoica/kmono/releases/tag/v4.12.1-fix1