### PR TITLE
Add support for passing -Sdeps overrides

### DIFF
--- a/packages/kmono-cli/deps.edn
+++ b/packages/kmono-cli/deps.edn
@@ -6,6 +6,7 @@
         babashka/process {:mvn/version "0.6.24"}
         org.babashka/cli {:mvn/version "0.8.67"}
         metosin/jsonista {:mvn/version "0.3.13"}
+        meta-merge/meta-merge {:mvn/version "1.0.0"}
         org.slf4j/slf4j-nop {:mvn/version "2.0.17"}
 
         com.kepler16/kmono-core {:local/root "../kmono-core"}

--- a/packages/kmono-cli/src/k16/kmono/cli/commands/clojure.clj
+++ b/packages/kmono-cli/src/k16/kmono/cli/commands/clojure.clj
@@ -1,6 +1,7 @@
 (ns k16.kmono.cli.commands.clojure
   (:require
    [babashka.process :as proc]
+   [clojure.edn :as edn]
    [clojure.java.io :as io]
    [clojure.string :as str]
    [k16.kmono.cli.common.context :as common.context]
@@ -10,7 +11,8 @@
    [k16.kmono.core.packages :as core.packages]
    [k16.kmono.cp :as kmono.cp]
    [k16.kmono.log :as log]
-   [k16.kmono.version :as kmono.version]))
+   [k16.kmono.version :as kmono.version]
+   [meta-merge.core :as metamerge]))
 
 (set! *warn-on-reflection* true)
 
@@ -43,7 +45,8 @@
                X "X")
 
         sdeps-aliases (core.deps/generate-sdeps-aliases root packages)
-        sdeps {:aliases sdeps-aliases}
+        sdeps (metamerge/meta-merge {:aliases sdeps-aliases}
+                                    (or (:sdeps props) {}))
 
         aliases (kmono.cp/collect-aliases config packages)
 
@@ -88,8 +91,15 @@
              :changed-since opts/changed-since-opt
              :filter opts/package-filter-opt
 
+             :sdeps {:desc "Extra deps to merge with kmono-generated sdeps (equivalent to clojure -Sdeps)"
+                     :alias :D
+                     :coerce :string
+                     :parse-fn (fn -parse-sdeps [value]
+                                 (some-> value edn/read-string))}
+
              :A {:desc "Aliases"
                  :parse-fn opts/parse-bool-or-aliases}
+
              :M {:desc "Main aliases"
                  :parse-fn opts/parse-bool-or-aliases}
              :T {:desc "Tool aliases"


### PR DESCRIPTION
Currently there is no supported way of using kmono's Sdeps overrides _and_ providing additional user-overrides.

You might want to do something like:

```bash
kmono clojure -A -- -Sdeps '{}'
```

But this will just _replace_ all the kmono-generated Sdeps.

---

This patch fixes the problem by providing a first-class `--sdeps -D` command which will be deep-merged with the kmono-generated deps.