### PR TITLE
feat: Support older java versions, preserving functionality

### DIFF
--- a/packages/kmono-core/src/k16/kmono/core/thread.clj
+++ b/packages/kmono-core/src/k16/kmono/core/thread.clj
@@ -6,8 +6,13 @@
 
 (set! *warn-on-reflection* true)
 
+(defmacro ^:private default-executor []
+  (if (>= (.feature (Runtime/version)) 21)
+    `(Executors/newVirtualThreadPerTaskExecutor)
+    `(Executors/newCachedThreadPool)))
+
 (def ^:dynamic ^:private *executor*
-  (Executors/newVirtualThreadPerTaskExecutor))
+  (default-executor))
 
 (defmacro vthread [& body]
   `(let [^Callable fn# (bound-fn [] ~@body)]


### PR DESCRIPTION
We are using java 17 on our build & release VMs which breaks using kmono due to reliance on virtual threads. With this change, virtual threads are only used on Java  21+. As per the comment, using this logic instead of reflection to ensure GraalVM still compiles the cli. 

Tested both cli compilation and running on Java 17 and now all work. 

Happy to do any further changes if you need it!